### PR TITLE
feat: Add pdfType to response in pyp, pyq, and sqp controllers

### DIFF
--- a/backend/controller/pypController.js
+++ b/backend/controller/pypController.js
@@ -86,6 +86,7 @@ export const getPyps = async (req, res) => {
       _id: pyp._id,
       class: pyp.class,
       subject: pyp.subject,
+      pdfType: pyp.pdfType,
       pdfs: (pyp.pdfs || []).map(pdf => ({
         url: `data:application/pdf;base64,${pdf.data.toString('base64')}`,
         fileType: 'pdf'

--- a/backend/controller/pyqController.js
+++ b/backend/controller/pyqController.js
@@ -88,6 +88,7 @@ export const getPyqs = async (req, res) => {
       class: pyq.class,
       subject: pyq.subject,
       chapter: pyq.chapter,
+      pdfType: pyq.pdfType,
       pdfs: (pyq.pdfs || []).map(pdf => ({
         url: `data:application/pdf;base64,${pdf.data.toString('base64')}`,
         fileType: 'pdf'

--- a/backend/controller/sqpController.js
+++ b/backend/controller/sqpController.js
@@ -88,6 +88,7 @@ export const getSqps = async (req, res) => {
       class: sqp.class,
       subject: sqp.subject,
       chapter: sqp.chapter,
+      pdfType: sqp.pdfType,
       pdfs: (sqp.pdfs || []).map(pdf => ({
         url: `data:application/pdf;base64,${pdf.data.toString('base64')}`,
         fileType: 'pdf'


### PR DESCRIPTION
- Included pdfType in the response object for getPyps, getPyqs, and getSqps functions to provide additional metadata for PDF files.